### PR TITLE
Nightscout State Announcements

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,17 +8,17 @@
 Lookout provides a rig-based interface to a Dexcom G5 CGM using Bluetooth Low Energy (BLE).  Lookout connects to the G5 transmitter and provides the following capabilities:
 - start and stop sensor sessions
 - view reported glucose values
-- send the values to OpenAPS and Nightscout
-- provide finger stick calibration values to the transmitter
-- reset an expired transmitter
-- calculates trend and noise values and reports them in glucose records sent to Nightscout and OpenAPS
-- calculates G5 calibration slope and offset values and reports them to Nightscout
-- reports BG Check records to Nightscout obtained from the transmitter's reported G5 calibration events
-- provides extended sensor operation beyond the sensor expiration.
+- send glucose values to OpenAPS and Nightscout
+- send finger stick calibration values to the transmitter
+- reset expired transmitters
+- calculate and report trend and noise values
+- calculate and report G5 calibration slope and offset values
+- report BG Check records to Nightscout obtained from transmitter's G5 calibration events
+- extend sensor operation beyond sensor expiration (limitations described below)
 
-Lookout is intended for use with the unexpired G5 transmitters and relies on the official G5 calibration mechanisms to calibrated the raw sensor values.  Lookout provides the user with the ability to reset expired transmitters to allow them to be used past their factory expiration dates.
+Lookout is intended for use with the unexpired G5 transmitters and relies on the official G5 calibration built into the transmitter to calibrate the raw sensor values.  Lookout provides the user with the ability to reset expired transmitters allowing them to be used past their normal expiration dates.
 
-Lookout can be run in parallel with a Dexcom receiver.  However, it cannot run in parallel with a Dexcom app on a phone as only one of the devices will connect to a transmitter at a time, and swapping devices requires approximately 15 minutes of the transmitter being unable to communicate with the device it was talking with.
+Lookout can be run in parallel with a Dexcom receiver.  However, it cannot run in parallel with a Dexcom or xDrip app on a phone as only one of the devices will connect to a transmitter at a time. Swapping devices requires approximately 15 minutes of the transmitter being unable to communicate with the device it was talking with before it will begin to talk to a new device.
 
 ## Pre-installation
 You must update your rig's NodeJS based on https://github.com/xdrip-js/xdrip-js/wiki (only use the "Updating NodeJS" section of those instructions, you should not install xdrip-js manually, it will be installed in the next step as part of Lookout.)

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ To view the app, open a browser and navigate to `http://<local IP address>:3000`
 Once the browser is open to your Lookout page (see above steps), you can start the sensor and calibrate through it. (Note that you can also continue using the Dexcom receiver alongside Lookout to do these things as well. Both the receiver and Lookout will get the latest updates from the G5 transmitter after a reading or two, provided they are in range and connected.)
 
 * click "Menu" (bottom right button) on the Lookout page, then `CGM` and `Transmitter`, then `Pair new`, and enter your transmitter ID (note it is case-sensitive), then `Save`
-* put the sensor/transmitter on your body, if you haven't already, and press the `Home`/person button at the bottom left of the lookout page, then click `Start sensor` (this part is identical to the receiver, which you can also use at the same time, alternatively, to start the sensor).
+* put the sensor/transmitter on your body, if you haven't already, and press the "Home"/person button at the bottom left of the lookout page, then click `Start sensor` (this part is identical to the receiver, which you can also use at the same time, alternatively, to start the sensor).
 * wait 5 minutes and press the `Menu` button, then `CGM` and `Sensor`, the `State` should show as `Warmup`. Press the "Home" screen (bottom left, person button), you will also see this state here after a while.
 * after 2 hours the state will change to `First calibration` - enter the first calibration by clicking the `Calibration` button and entering the value from a finger stick.
 * after 5 minutes the state will change to `Second calibration` - enter the second calibration by clicking the `Calibration` button and entering the value from a finger stick.
@@ -77,7 +77,7 @@ Once the browser is open to your Lookout page (see above steps), you can start t
 ## Reset a Transmitter
 * Ensure the transmitter ID is entered as described above.
 * Click "Menu" on the Lookout page, then `CGM` and `Transmitter`, then `Reset Transmitter`, then `Reset`
-* wait 5 minutes and press the "Menu" button, then `CGM` and `Transmitter`, the Age should show as less than a day.
+* wait 5 minutes and press the "Menu" button, then `CGM` and `Transmitter`, the `Age` should show as less than a day.
 * After successfully resetting the transmitter, follow the instructions above to start a sensor session.
 
 ## Making it permanent

--- a/README.md
+++ b/README.md
@@ -14,7 +14,9 @@ Lookout provides a rig-based interface to a Dexcom G5 CGM using Bluetooth Low En
 - calculate and report trend and noise values
 - calculate and report G5 calibration slope and offset values
 - report BG Check records to Nightscout obtained from transmitter's G5 calibration events
+- report sensor state changes to Nightscout as announcements
 - extend sensor operation beyond sensor expiration (limitations described below)
+- report raw unfiltered values to Nightscout during warmup for trend visibility
 
 Lookout is intended for use with the unexpired G5 transmitters and relies on the official G5 calibration built into the transmitter to calibrate the raw sensor values.  Lookout provides the user with the ability to reset expired transmitters allowing them to be used past their normal expiration dates.
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ To look at the Lookout log, for debug purposes, type `cat /var/log/openaps/xdrip
 ## Options
 * `--extend_sensor`: Lookout uses the calibrated and unfiltered values reported by the G5 to calculate the running calibration slope and intercept values whenever the current calibration values it has produces a calibrated value that is more than 5 mg/dL away from the G5 reported calibrated value.  If the `--extend_sensor` option is enabled, Lookout will apply the most recent calculated calibration to the G5's unfiltered value if the transmitter does not report a calibrated SGV.  This enables Lookout to continue reporting SGV values to Nightscout and OpenAPS after the sensor session is ended, providing greater flexibility on when the user changes the site.  This is not intended to extend a sensor life past 24 hours due to the lack of an ongoing calibration update mechanism.
 
-**WARNING** If running in exended sensor mode, the user must enter a `Sensor Start` in Nightscout to notify Lookout to stop reporting glucose values.
+**WARNING** If running in extended sensor mode, the user must enter a `Sensor Start` in Nightscout to notify Lookout to stop reporting glucose values.
 
 ## Reverting NodeJS
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,9 @@ If you later need to revert your rig's NodeJS to the legacy version, follow the 
 
 Lookout uses the bluez-tools software. Here are the instructions for installing bluez-tools:
 
+```
 sudo apt-get install bluez-tools
+```
 
 
 ## Installation
@@ -88,12 +90,12 @@ So far in the above you've only run Lookout from the command line - the next tim
 ```
 
 ## Debugging
-To look at the Lookout log, for debug purposes, type "cat /var/log/openaps/xdrip-js.log" or "tail -n 100 -F /var/log/openaps/xdrip-js.log" (without the quotes).
+To look at the Lookout log, for debug purposes, type `cat /var/log/openaps/xdrip-js.log` or `tail -n 100 -F /var/log/openaps/xdrip-js.log` (without the quotes).
 
 ## Options
 * `--extend_sensor`: Lookout uses the calibrated and unfiltered values reported by the G5 to calculate the running calibration slope and intercept values whenever the current calibration values it has produces a calibrated value that is more than 5 mg/dL away from the G5 reported calibrated value.  If the `--extend_sensor` option is enabled, Lookout will apply the most recent calculated calibration to the G5's unfiltered value if the transmitter does not report a calibrated SGV.  This enables Lookout to continue reporting SGV values to Nightscout and OpenAPS after the sensor session is ended, providing greater flexibility on when the user changes the site.  This is not intended to extend a sensor life past 24 hours due to the lack of an ongoing calibration update mechanism.
 
-** CAUTION ** If running in exended sensor mode, the user must enter a `Sensor Start` in Nightscout to notify Lookout to stop reporting glucose values.
+**WARNING** If running in exended sensor mode, the user must enter a `Sensor Start` in Nightscout to notify Lookout to stop reporting glucose values.
 
 ## Reverting NodeJS
 

--- a/README.md
+++ b/README.md
@@ -67,30 +67,30 @@ To view the app, open a browser and navigate to `http://<local IP address>:3000`
 ## Using the browser to control your G5
 Once the browser is open to your Lookout page (see above steps), you can start the sensor and calibrate through it. (Note that you can also continue using the Dexcom receiver alongside Lookout to do these things as well. Both the receiver and Lookout will get the latest updates from the G5 transmitter after a reading or two, provided they are in range and connected.)
 
-* click "Menu" (bottom right button) on the Lookout page, then "CGM" and "Transmitter", then "Pair new", and enter your transmitter ID (note it is case-sensitive), then "Save"
-* put the sensor/transmitter on your body, if you haven't already, and press the "Home"/person button at the bottom left of the lookout page, then click "Start sensor" (this part is identical to the receiver, which you can also use at the same time, alternatively, to start the sensor).
-* wait 5 minutes and press the "Menu" button, then "CGM" and "Sensor", the "State" should show as "Warmup". Press the "Home" screen (bottom left, person button), you will also see this state here after a while.
-* after 2 hours the state will change to "First calibration" - enter the first calibration by clicking the "Calibration" button and entering the value from a finger stick.
-* after 5 minutes the state will change to "Second calibration" - enter the second calibration by clicking the "Calibration" button and entering the value from a finger stick.
-* after 5 minutes the state will change to "OK" and dexcom-calibrated BG values will be displayed.
+* click "Menu" (bottom right button) on the Lookout page, then `CGM` and `Transmitter`, then `Pair new`, and enter your transmitter ID (note it is case-sensitive), then `Save`
+* put the sensor/transmitter on your body, if you haven't already, and press the `Home`/person button at the bottom left of the lookout page, then click `Start sensor` (this part is identical to the receiver, which you can also use at the same time, alternatively, to start the sensor).
+* wait 5 minutes and press the `Menu` button, then `CGM` and `Sensor`, the `State` should show as `Warmup`. Press the "Home" screen (bottom left, person button), you will also see this state here after a while.
+* after 2 hours the state will change to `First calibration` - enter the first calibration by clicking the `Calibration` button and entering the value from a finger stick.
+* after 5 minutes the state will change to `Second calibration` - enter the second calibration by clicking the `Calibration` button and entering the value from a finger stick.
+* after 5 minutes the state will change to `OK` and dexcom-calibrated BG values will be displayed.
 
 ## Reset a Transmitter
 * Ensure the transmitter ID is entered as described above.
-* Click "Menu" on the Lookout page, then "CGM" and "Transmitter", then "Reset Transmitter", then "Reset"
-* wait 5 minutes and press the "Menu" button, then "CGM" and "Transmitter", the Age should show as less than a day.
+* Click "Menu" on the Lookout page, then `CGM` and `Transmitter`, then `Reset Transmitter`, then `Reset`
+* wait 5 minutes and press the "Menu" button, then `CGM` and `Transmitter`, the Age should show as less than a day.
 * After successfully resetting the transmitter, follow the instructions above to start a sensor session.
 
 ## Making it permanent
 So far in the above you've only run Lookout from the command line - the next time you close your terminal, or reboot your rig, it will only run if you add it to your crontab:
 ```
-<type the command "crontab -e" (without quotes) and add this line:>
+<type the command `crontab -e` and add this line:>
 @reboot Lookout >> /var/log/openaps/xdrip-js.log
 <save and exit your editor>
-<reboot your rig with the command "reboot" (without quotes)>
+<reboot your rig with the command `reboot`>
 ```
 
 ## Debugging
-To look at the Lookout log, for debug purposes, type `cat /var/log/openaps/xdrip-js.log` or `tail -n 100 -F /var/log/openaps/xdrip-js.log` (without the quotes).
+To look at the Lookout log, for debug purposes, type `cat /var/log/openaps/xdrip-js.log` or `tail -n 100 -F /var/log/openaps/xdrip-js.log`.
 
 ## Options
 * `--extend_sensor`: Lookout uses the calibrated and unfiltered values reported by the G5 to calculate the running calibration slope and intercept values whenever the current calibration values it has produces a calibrated value that is more than 5 mg/dL away from the G5 reported calibrated value.  If the `--extend_sensor` option is enabled, Lookout will apply the most recent calculated calibration to the G5's unfiltered value if the transmitter does not report a calibrated SGV.  This enables Lookout to continue reporting SGV values to Nightscout and OpenAPS after the sensor session is ended, providing greater flexibility on when the user changes the site.  This is not intended to extend a sensor life past 24 hours due to the lack of an ongoing calibration update mechanism.

--- a/README.md
+++ b/README.md
@@ -5,9 +5,20 @@
 *Please note this project is neither created nor backed by Dexcom, Inc. This software is not intended for use in therapy.*
 
 ## Overview
-Lookout provides a rig-based interface to a Dexcom G5 CGM using Bluetooth Low Energy (BLE).  Lookout connects to the G5 transmitter, and provides the capabilities for the user to start and stop sensor sessions, view reported glucose values, send the values to OpenAPS and Nightscout, provide calibration values to the transmitter, and reset a transmitter.  Lookout also calculates trend and noise values to include in glucose records sent to Nightscout and OpenAPS, calculates G5 calibration values and reports them to Nightscout, reports BG Check records to Nightscout obtained from the transmitter's reported G5 calibration events, and provides extended sensor operation beyond the sensor expiration.
+Lookout provides a rig-based interface to a Dexcom G5 CGM using Bluetooth Low Energy (BLE).  Lookout connects to the G5 transmitter and provides the following capabilities:
+- start and stop sensor sessions
+- view reported glucose values
+- send the values to OpenAPS and Nightscout
+- provide finger stick calibration values to the transmitter
+- reset an expired transmitter
+- calculates trend and noise values and reports them in glucose records sent to Nightscout and OpenAPS
+- calculates G5 calibration slope and offset values and reports them to Nightscout
+- reports BG Check records to Nightscout obtained from the transmitter's reported G5 calibration events
+- provides extended sensor operation beyond the sensor expiration.
 
 Lookout is intended for use with the unexpired G5 transmitters and relies on the official G5 calibration mechanisms to calibrated the raw sensor values.  Lookout provides the user with the ability to reset expired transmitters to allow them to be used past their factory expiration dates.
+
+Lookout can be run in parallel with a Dexcom receiver.  However, it cannot run in parallel with a Dexcom app on a phone as only one of the devices will connect to a transmitter at a time, and swapping devices requires approximately 15 minutes of the transmitter being unable to communicate with the device it was talking with.
 
 ## Pre-installation
 You must update your rig's NodeJS based on https://github.com/xdrip-js/xdrip-js/wiki (only use the "Updating NodeJS" section of those instructions, you should not install xdrip-js manually, it will be installed in the next step as part of Lookout.)

--- a/README.md
+++ b/README.md
@@ -4,6 +4,11 @@
 
 *Please note this project is neither created nor backed by Dexcom, Inc. This software is not intended for use in therapy.*
 
+## Overview
+Lookout provides a rig-based interface to a Dexcom G5 CGM using Bluetooth Low Energy (BLE).  Lookout connects to the G5 transmitter, and provides the capabilities for the user to start and stop sensor sessions, view reported glucose values, send the values to OpenAPS and Nightscout, provide calibration values to the transmitter, and reset a transmitter.  Lookout also calculates trend and noise values to include in glucose records sent to Nightscout and OpenAPS, calculates G5 calibration values and reports them to Nightscout, reports BG Check records to Nightscout obtained from the transmitter's reported G5 calibration events, and provides extended sensor operation beyond the sensor expiration.
+
+Lookout is intended for use with the unexpired G5 transmitters and relies on the official G5 calibration mechanisms to calibrated the raw sensor values.  Lookout provides the user with the ability to reset expired transmitters to allow them to be used past their factory expiration dates.
+
 ## Pre-installation
 You must update your rig's NodeJS based on https://github.com/xdrip-js/xdrip-js/wiki (only use the "Updating NodeJS" section of those instructions, you should not install xdrip-js manually, it will be installed in the next step as part of Lookout.)
 As of 13-Jun-2018, these steps are:
@@ -56,6 +61,12 @@ Once the browser is open to your Lookout page (see above steps), you can start t
 * after 5 minutes the state will change to "Second calibration" - enter the second calibration by clicking the "Calibration" button and entering the value from a finger stick.
 * after 5 minutes the state will change to "OK" and dexcom-calibrated BG values will be displayed.
 
+## Reset a Transmitter
+* Ensure the transmitter ID is entered as described above.
+* Click "Menu" on the Lookout page, then "CGM" and "Transmitter", then "Reset Transmitter", then "Reset"
+* wait 5 minutes and press the "Menu" button, then "CGM" and "Transmitter", the Age should show as less than a day.
+* After successfully resetting the transmitter, follow the instructions above to start a sensor session.
+
 ## Making it permanent
 So far in the above you've only run Lookout from the command line - the next time you close your terminal, or reboot your rig, it will only run if you add it to your crontab:
 ```
@@ -67,6 +78,11 @@ So far in the above you've only run Lookout from the command line - the next tim
 
 ## Debugging
 To look at the Lookout log, for debug purposes, type "cat /var/log/openaps/xdrip-js.log" or "tail -n 100 -F /var/log/openaps/xdrip-js.log" (without the quotes).
+
+## Options
+* `--extend_sensor`: Lookout uses the calibrated and unfiltered values reported by the G5 to calculate the running calibration slope and intercept values whenever the current calibration values it has produces a calibrated value that is more than 5 mg/dL away from the G5 reported calibrated value.  If the `--extend_sensor` option is enabled, Lookout will apply the most recent calculated calibration to the G5's unfiltered value if the transmitter does not report a calibrated SGV.  This enables Lookout to continue reporting SGV values to Nightscout and OpenAPS after the sensor session is ended, providing greater flexibility on when the user changes the site.  This is not intended to extend a sensor life past 24 hours due to the lack of an ongoing calibration update mechanism.
+
+** CAUTION ** If running in exended sensor mode, the user must enter a `Sensor Start` in Nightscout to notify Lookout to stop reporting glucose values.
 
 ## Reverting NodeJS
 

--- a/calcStats.js
+++ b/calcStats.js
@@ -65,7 +65,7 @@ const calcNoise = (sgvArr) => {
   return noise;
 };
 
-exports.calcSensorNoise = (glucoseHist, calibration) => {
+exports.calcSensorNoise = (glucoseHist, lastCal) => {
   const MAXRECORDS=8;
   const MINRECORDS=4;
   let sgvArr = [];
@@ -76,7 +76,7 @@ exports.calcSensorNoise = (glucoseHist, calibration) => {
       // use the unfiltered data with the most recent calculated calibration value
       // this will provide a noise calculation that is independent of calibration jumps
       sgvArr.push({
-        'glucose': calibration.calcGlucose(glucoseHist[i], calibration),
+        'glucose': calibration.calcGlucose(glucoseHist[i], lastCal),
         'readDate': glucoseHist[i].readDate
       });
     }
@@ -90,7 +90,7 @@ exports.calcSensorNoise = (glucoseHist, calibration) => {
 };
 
 // Return 10 minute trend total
-exports.calcTrend = (glucoseHist, calibration) => {
+exports.calcTrend = (glucoseHist, lastCal) => {
   let sgvHist = null;
 
   let trend = 0;
@@ -119,7 +119,7 @@ exports.calcTrend = (glucoseHist, calibration) => {
       // Use the current calibration value to calculate the glucose from the
       // unfiltered data. This allows the trend calculation to be independent
       // of the calibration jumps
-      totalDelta = calibration.calcGlucose(sgvHist[sgvHist.length-1], calibration) - calibration.calcGlucose(sgvHist[0], calibration);
+      totalDelta = calibration.calcGlucose(sgvHist[sgvHist.length-1], lastCal) - calibration.calcGlucose(sgvHist[0], lastCal);
 
       timeSpan = (maxDate - minDate)/1000.0/60.0;
 

--- a/calcStats.js
+++ b/calcStats.js
@@ -70,7 +70,9 @@ exports.calcSensorNoise = (glucoseHist, lastCal) => {
   const MINRECORDS=4;
   let sgvArr = [];
 
-  for (let i = (glucoseHist.length-MAXRECORDS-1); i < glucoseHist.length; ++i) {
+  let numRecords = Math.max(glucoseHist.length-MAXRECORDS-1, 0);
+
+  for (let i = numRecords; i < glucoseHist.length; ++i) {
     // Only use values that are > 30 to filter out invalid values.
     if (glucoseHist[i].glucose > 30) {
       // use the unfiltered data with the most recent calculated calibration value

--- a/calibration.js
+++ b/calibration.js
@@ -218,3 +218,7 @@ exports.calculateG5Calibration = (lastCal, lastG5CalTime, glucoseHist, currSGV) 
   }
 };
 
+exports.calcGlucose = (sgv, calibration) => {
+  return Math.round((sgv.unfiltered-calibration.intercept)/calibration.slope);
+};
+

--- a/syncNS.js
+++ b/syncNS.js
@@ -196,6 +196,11 @@ const syncSGVs = async () => {
     let rigSGV = rigSGVs[rigIndex];
     let nsSGV = null;
 
+    if (!rigSGV.glucose) {
+      // Do not attempt to send an invalid glucose to NS
+      continue;
+    }
+
     for (; nsIndex < nsSGVs.length; ++nsIndex) {
       let timeDiff = moment(nsSGVs[nsIndex].dateString).diff(moment(rigSGV.readDate));
 

--- a/test.js
+++ b/test.js
@@ -3,17 +3,13 @@
 require('should');
 
 var stats = require('./calcStats');
+var calibration = require('./calibration');
 
-describe('Stats', function() {
+describe('Test Stats', function() {
 
   it('should calculate Sensor Noise', function() {
 
-    var glucoseHist = [{
-      'i': 0,
-      'start': '00:00:00',
-      'rate': 1,
-      'minutes': 0
-    }, {
+    let glucoseHist = [{
       'inSession': true,
       'status': 0,
       'state': 7,
@@ -104,7 +100,9 @@ describe('Stats', function() {
       'rssi': -77,
       'g5calibrated': true,
       'stateString': 'Need calibration',
-    }, {
+    }];
+
+    let currSGV = {
       'inSession': true,
       'status': 0,
       'state': 7,
@@ -117,12 +115,69 @@ describe('Stats', function() {
       'rssi': -79,
       'g5calibrated': true,
       'stateString': 'Need calibration',
-    }];
+    };
 
-    var noise = stats.calcSensorNoise(glucoseHist);
+    let lastCal = calibration.calculateG5Calibration(null, 0, glucoseHist, currSGV);
+
+    glucoseHist.push(currSGV);
+
+    let noise = stats.calcSensorNoise(glucoseHist, lastCal);
 
     noise.should.be.greaterThan(0.02);
     noise.should.be.lessThan(0.03);
   });
 
+  it('should not calculate Sensor Noise if not enough records', function() {
+
+    let glucoseHist = [{
+      'inSession': true,
+      'status': 0,
+      'state': 7,
+      'readDate': 1528890389945,
+      'filtered': 161.056,
+      'unfiltered': 158.4,
+      'glucose': 155,
+      'trend': -3.9982585362819747,
+      'canBeCalibrated': true,
+      'rssi': -59,
+      'g5calibrated': true,
+      'stateString': 'Need calibration',
+    }, {
+      'inSession': true,
+      'status': 0,
+      'state': 7,
+      'readDate': 1528890689766,
+      'filtered': 159.36,
+      'unfiltered': 156.544,
+      'glucose': 153,
+      'trend': -3.9992534726850986,
+      'canBeCalibrated': true,
+      'rssi': -63,
+      'g5calibrated': true,
+      'stateString': 'Need calibration',
+    }];
+
+    let currSGV = {
+      'inSession': true,
+      'status': 0,
+      'state': 7,
+      'readDate': 1528892489488,
+      'filtered': 145.92,
+      'unfiltered': 141.632,
+      'glucose': 134,
+      'trend': -7.334767687903413,
+      'canBeCalibrated': true,
+      'rssi': -79,
+      'g5calibrated': true,
+      'stateString': 'Need calibration',
+    };
+
+    let lastCal = calibration.calculateG5Calibration(null, 0, glucoseHist, currSGV);
+
+    glucoseHist.push(currSGV);
+
+    let noise = stats.calcSensorNoise(glucoseHist, lastCal);
+
+    noise.should.equal(0);
+  });
 });

--- a/transmitterIO.js
+++ b/transmitterIO.js
@@ -15,7 +15,6 @@ module.exports = async (io, extend_sensor_opt) => {
   let extend_sensor = extend_sensor_opt;
   let worker = null;
   let timerObj = null;
-  let SGVStorageLocked = false;
 
   const removeBTDevice = (id) => {
     var btName = 'Dexcom'+id.slice(-2);
@@ -30,25 +29,6 @@ module.exports = async (io, extend_sensor_opt) => {
       console.log(`stdout: ${stdout}`);
       console.log(`stderr: ${stderr}`);
     });
-  };
-
-  const getLastG5Cal = (bgChecks) => {
-    let lastG5Cal = null;
-
-    if (bgChecks) {
-      for (let ii=(bgChecks.length-1); ii >= 0; --ii) {
-        if (bgChecks[ii].type == 'G5') {
-          lastG5Cal = bgChecks[ii];
-          break;
-        }
-      }
-    }
-
-    return lastG5Cal;
-  };
-
-  const calcGlucose = (sgv, calibration) => {
-    return Math.round((sgv.unfiltered-calibration.intercept)/calibration.slope);
   };
 
   const getLastG5Cal = (bgChecks) => {

--- a/transmitterIO.js
+++ b/transmitterIO.js
@@ -15,6 +15,7 @@ module.exports = async (io, extend_sensor_opt) => {
   let extend_sensor = extend_sensor_opt;
   let worker = null;
   let timerObj = null;
+  let SGVStorageLocked = false;
 
   const removeBTDevice = (id) => {
     var btName = 'Dexcom'+id.slice(-2);

--- a/transmitterIO.js
+++ b/transmitterIO.js
@@ -120,26 +120,26 @@ module.exports = async (io, extend_sensor_opt) => {
       console.log('Calibrated SGV: ' + sgv.glucose + ' unfiltered: ' + sgv.unfiltered + ' slope: ' + lastCal.slope + ' intercept: ' + lastCal.intercept);
 
       sgv.g5calibrated = false;
+    }
 
-      if (sensorInsert && (sensorInsert.diff(moment(lastCal.date).subtract(6, 'minutes')) > 0)) {
-        console.log('Found sensor insert after latest calibration. Deleting calibration data.');
-        await storage.del('g5Calibration');
-        await storage.del('bgChecks');
-        await storage.del('glucoseHist');
+    if (sensorInsert && (sensorInsert.diff(moment(lastCal.date).subtract(6, 'minutes')) > 0)) {
+      console.log('Found sensor insert after latest calibration. Deleting calibration data.');
+      await storage.del('g5Calibration');
+      await storage.del('bgChecks');
+      await storage.del('glucoseHist');
 
-        newCal = {
-          date: Date.now(),
-          scale: 1,
-          intercept: 0,
-          slope: 1,
-          type: 'Unity'
-        };       
+      newCal = {
+        date: Date.now(),
+        scale: 1,
+        intercept: 0,
+        slope: 1,
+        type: 'Unity'
+      };       
 
-        // set the glucose value to null
-        // so it doesn't show up in the Lookout GUI
-        sgv.glucose = null;
-        sendSGV = false;
-      }
+      // set the glucose value to null
+      // so it doesn't show up in the Lookout GUI
+      sgv.glucose = null;
+      sendSGV = false;
     }
 
     if (newCal) {

--- a/transmitterIO.js
+++ b/transmitterIO.js
@@ -66,10 +66,6 @@ module.exports = async (io, extend_sensor_opt) => {
     return lastG5Cal;
   };
 
-  const calcGlucose = (sgv, calibration) => {
-    return Math.round((sgv.unfiltered-calibration.intercept)/calibration.slope);
-  };
-
   const processNewGlucose = async (sgv) => {
     let lastCal = null;
     let glucoseHist = null;
@@ -134,7 +130,7 @@ module.exports = async (io, extend_sensor_opt) => {
     }
 
     if (!sgv.glucose && extend_sensor && lastCal && (lastCal.type !== 'Unity')) {
-      sgv.glucose = calcGlucose(sgv, lastCal);
+      sgv.glucose = calibration.calcGlucose(sgv, lastCal);
 
       console.log('Invalid glucose value received from transmitter, replacing with calibrated unfiltered value');
       console.log('Calibrated SGV: ' + sgv.glucose + ' unfiltered: ' + sgv.unfiltered + ' slope: ' + lastCal.slope + ' intercept: ' + lastCal.intercept);
@@ -183,11 +179,11 @@ module.exports = async (io, extend_sensor_opt) => {
     // Store it regardless for state change history
     glucoseHist.push(sgv);
 
-    if (sendSGV) {
-      // a valid SGV value is available, so calculate trend and noise
-      sgv.trend = stats.calcTrend(glucoseHist);
+    if (lastCal) {
+      // a valid calibration is available to use
+      sgv.trend = stats.calcTrend(glucoseHist, lastCal);
 
-      sgv.noise = stats.calcSensorNoise(glucoseHist);
+      sgv.noise = stats.calcSensorNoise(glucoseHist, lastCal);
     } else {
       // No way to calculate a trend since we don't know the calibration slope
       sgv.trend = 0;
@@ -196,7 +192,7 @@ module.exports = async (io, extend_sensor_opt) => {
       sgv.noise = .4;
     }
 
-    sgv.nsNoise = calcNSNoise(sgv.noise, glucoseHist);
+    sgv.nsNoise = stats.calcNSNoise(sgv.noise, glucoseHist);
 
     console.log('Current sensor trend: ' + Math.round(sgv.trend*10)/10 + ' Sensor Noise: ' + Math.round(sgv.noise*1000)/1000 + ' NS Noise: ' + sgv.nsNoise);
 

--- a/transmitterIO.js
+++ b/transmitterIO.js
@@ -122,7 +122,7 @@ module.exports = async (io, extend_sensor_opt) => {
       sgv.g5calibrated = false;
     }
 
-    if (sensorInsert && (sensorInsert.diff(moment(lastCal.date).subtract(6, 'minutes')) > 0)) {
+    if (sensorInsert && lastCal && (sensorInsert.diff(moment(lastCal.date).subtract(6, 'minutes')) > 0) && (lastCal.type !== 'Unity')) {
       console.log('Found sensor insert after latest calibration. Deleting calibration data.');
       await storage.del('g5Calibration');
       await storage.del('bgChecks');

--- a/transmitterIO.js
+++ b/transmitterIO.js
@@ -177,9 +177,7 @@ module.exports = async (io, extend_sensor_opt) => {
     }
 
     if (sendSGV) {
-      // a valid SGV value is ready to store and send
-      glucoseHist.push(sgv);
-
+      // a valid SGV value is available, so calculate trend and noise
       sgv.trend = stats.calcTrend(glucoseHist);
 
       sgv.noise = stats.calcSensorNoise(glucoseHist);
@@ -187,8 +185,10 @@ module.exports = async (io, extend_sensor_opt) => {
       sgv.nsNoise = stats.calcNSNoise(sgv.noise, glucoseHist);
 
       console.log('Current sensor trend: ' + Math.round(sgv.trend*10)/10 + ' Sensor Noise: ' + Math.round(sgv.noise*1000)/1000 + ' NS Noise: ' + sgv.nsNoise);
-
     }
+
+    // Store it regardless for state change history
+    glucoseHist.push(sgv);
 
     await storeNewGlucose(glucoseHist)
       .catch(() => {

--- a/transmitterIO.js
+++ b/transmitterIO.js
@@ -36,7 +36,7 @@ module.exports = async (io, extend_sensor_opt) => {
 
     if (bgChecks) {
       for (let ii=(bgChecks.length-1); ii >= 0; --ii) {
-        if (bgChecks[ii].type == 'G5') {
+        if ((bgChecks[ii].type == 'G5') || (bgChecks[ii].type == 'Unity')) {
           lastG5Cal = bgChecks[ii];
           break;
         }

--- a/transmitterIO.js
+++ b/transmitterIO.js
@@ -103,6 +103,10 @@ module.exports = async (io, extend_sensor_opt) => {
 
     if (glucoseHist.length > 0) {
       newCal = calibration.calculateG5Calibration(lastCal, lastG5CalTime, glucoseHist, sgv);
+
+      if (sgv.state != glucoseHist[glucoseHist.length-1].state) {
+        xDripAPS.postAnnouncement('Sensor: ' + sgv.stateString);
+      }
     }
 
     if (newCal) {

--- a/transmitterIO.js
+++ b/transmitterIO.js
@@ -180,6 +180,9 @@ module.exports = async (io, extend_sensor_opt) => {
       sendSGV = false;
     }
 
+    // Store it regardless for state change history
+    glucoseHist.push(sgv);
+
     if (sendSGV) {
       // a valid SGV value is available, so calculate trend and noise
       sgv.trend = stats.calcTrend(glucoseHist);
@@ -192,9 +195,6 @@ module.exports = async (io, extend_sensor_opt) => {
       // Put in light noise to account for uncertainty
       sgv.noise = .4;
     }
-
-    // Store it regardless for state change history
-    glucoseHist.push(sgv);
 
     sgv.nsNoise = calcNSNoise(sgv.noise, glucoseHist);
 

--- a/transmitterIO.js
+++ b/transmitterIO.js
@@ -47,6 +47,25 @@ module.exports = async (io, extend_sensor_opt) => {
     return lastG5Cal;
   };
 
+  const calcGlucose = (sgv, calibration) => {
+    return Math.round((sgv.unfiltered-calibration.intercept)/calibration.slope);
+  };
+
+  const getLastG5Cal = (bgChecks) => {
+    let lastG5Cal = null;
+
+    if (bgChecks) {
+      for (let ii=(bgChecks.length-1); ii >= 0; --ii) {
+        if (bgChecks[ii].type == 'G5') {
+          lastG5Cal = bgChecks[ii];
+          break;
+        }
+      }
+    }
+
+    return lastG5Cal;
+  };
+
   const processNewGlucose = async (sgv) => {
     let lastCal = null;
     let glucoseHist = null;

--- a/xDripAPS.js
+++ b/xDripAPS.js
@@ -374,6 +374,42 @@ module.exports = () => {
       });
     },
 
+    updateBGCheck: (id, BGCheck) => {
+      let entry = convertBGCheck(BGCheck);
+
+      entry._id = id;
+
+      const secret = process.env.API_SECRET;
+      let ns_url = process.env.NIGHTSCOUT_HOST + '/api/v1/treatments/';
+      let ns_headers = {
+        'Content-Type': 'application/json'
+      };
+
+      if (secret.startsWith('token=')) {
+        ns_url = ns_url + '?' + secret;
+      } else {
+        ns_headers['API-SECRET'] = secret;
+      }
+
+      const optionsNS = {
+        url: ns_url,
+        method: 'PUT',
+        headers: ns_headers,
+        data: entry,
+        json: true
+      };
+
+      /*eslint-disable no-unused-vars*/
+      request(optionsNS, function (error, response, body) {
+      /*eslint-enable no-unused-vars*/
+        if (error) {
+          console.error('error posting json: ', error);
+        } else {
+          console.log('updated BG Check to NS, statusCode = ' + response.statusCode);
+        }
+      });
+    },
+
     postBGCheck: (BGCheck) => {
       let entry = convertBGCheck(BGCheck);
 

--- a/xDripAPS.js
+++ b/xDripAPS.js
@@ -410,6 +410,44 @@ module.exports = () => {
       });
     },
 
+    postAnnouncement: (message) => {
+      const entry = [{
+        'enteredBy': 'openaps://' + os.hostname(),
+        'eventType': 'Announcement',
+        'notes': message
+      }];
+
+      const secret = process.env.API_SECRET;
+      let ns_url = process.env.NIGHTSCOUT_HOST + '/api/v1/treatments.json';
+      let ns_headers = {
+        'Content-Type': 'application/json'
+      };
+
+      if (secret.startsWith('token=')) {
+        ns_url = ns_url + '?' + secret;
+      } else {
+        ns_headers['API-SECRET'] = secret;
+      }
+
+      const optionsNS = {
+        url: ns_url,
+        method: 'POST',
+        headers: ns_headers,
+        body: entry,
+        json: true
+      };
+
+      /*eslint-disable no-unused-vars*/
+      request(optionsNS, function (error, response, body) {
+      /*eslint-enable no-unused-vars*/
+        if (error) {
+          console.error('error posting json: ', error);
+        } else {
+          console.log('uploaded new Announcement to NS, statusCode = ' + response.statusCode);
+        }
+      });
+    },
+
     postBGCheck: (BGCheck) => {
       let entry = convertBGCheck(BGCheck);
 

--- a/xDripAPS.js
+++ b/xDripAPS.js
@@ -286,7 +286,7 @@ const queryBGChecksSince = (startTime) => {
   let ns_url = process.env.NIGHTSCOUT_HOST + '/api/v1/treatments.json?';
 
   // time format needs to match the output of 'date -d "3 hours ago" -Iminutes -u'
-  let ns_query = 'find[eventType][$regex]=Check&find[created_at][$gte]=' + startTime.toISOString();
+  let ns_query = 'find[eventType][$regex]=Check&find[created_at][$gte]=' + startTime.format();
 
   let ns_headers = {
     'Content-Type': 'application/json'
@@ -356,6 +356,7 @@ module.exports = () => {
 
       const optionsNS = {
         url: ns_url,
+        timeout: 30*1000,
         method: 'PUT',
         headers: ns_headers,
         data: entry,

--- a/xDripAPS.js
+++ b/xDripAPS.js
@@ -286,7 +286,7 @@ const queryBGChecksSince = (startTime) => {
   let ns_url = process.env.NIGHTSCOUT_HOST + '/api/v1/treatments.json?';
 
   // time format needs to match the output of 'date -d "3 hours ago" -Iminutes -u'
-  let ns_query = 'find[eventType][$regex]=Check&find[created_at][$gte]=' + startTime.format();
+  let ns_query = 'find[eventType][$regex]=Check&find[created_at][$gte]=' + startTime.toISOString();
 
   let ns_headers = {
     'Content-Type': 'application/json'

--- a/xDripAPS.js
+++ b/xDripAPS.js
@@ -356,43 +356,6 @@ module.exports = () => {
 
       const optionsNS = {
         url: ns_url,
-        timeout: 30*1000,
-        method: 'PUT',
-        headers: ns_headers,
-        data: entry,
-        json: true
-      };
-
-      /*eslint-disable no-unused-vars*/
-      request(optionsNS, function (error, response, body) {
-      /*eslint-enable no-unused-vars*/
-        if (error) {
-          console.error('error posting json: ', error);
-        } else {
-          console.log('updated BG Check to NS, statusCode = ' + response.statusCode);
-        }
-      });
-    },
-
-    updateBGCheck: (id, BGCheck) => {
-      let entry = convertBGCheck(BGCheck);
-
-      entry._id = id;
-
-      const secret = process.env.API_SECRET;
-      let ns_url = process.env.NIGHTSCOUT_HOST + '/api/v1/treatments/';
-      let ns_headers = {
-        'Content-Type': 'application/json'
-      };
-
-      if (secret.startsWith('token=')) {
-        ns_url = ns_url + '?' + secret;
-      } else {
-        ns_headers['API-SECRET'] = secret;
-      }
-
-      const optionsNS = {
-        url: ns_url,
         method: 'PUT',
         headers: ns_headers,
         data: entry,

--- a/xDripAPS.js
+++ b/xDripAPS.js
@@ -412,6 +412,7 @@ module.exports = () => {
 
     postAnnouncement: (message) => {
       const entry = [{
+        'created_at': moment().format(),
         'enteredBy': 'openaps://' + os.hostname(),
         'eventType': 'Announcement',
         'notes': message


### PR DESCRIPTION
New functionality:
- Sends announcements to NS when the sensor state changes
- Noise and trend calculations are now unaffected by the glucose discontinuities caused by calibration events.
- Continues to send raw glucose values to NS after session is ended that will be plotted as simply the raw values without calibration values