### PR TITLE
Expired Cal Mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,10 @@ To look at the Lookout log, for debug purposes, type `cat /var/log/openaps/xdrip
 
 **WARNING** If running in extended sensor mode, the user must enter a `Sensor Start` in Nightscout to notify Lookout to stop reporting glucose values.
 
+* `--expired_cal`: Lookout uses user entered BG Check and Sensor Start records to calibrate raw unfiltered values reported by the CGM transmitter. Lookout does not perform calibration for 15 minutes after a Sensor Start. During the first 12 hours after a Sensor Start, Lookout only uses a Single Point calibration algorithm that assumes a y axis intercept of 0.  After the first 12 hours, Lookout will switch to using a Least Squares Regression algorithm to calculate the y axis intercept and slope to convert the raw unfiltered values to calibrated glucose values.
+
+**WARNING** Expired calibration mode is in testing phase only and is NOT recommended. It is included in the code at this time so the user can monitor in the log file the delta between the official calibration values and the expired mode calculated calibration values.
+
 ## Reverting NodeJS
 
 in the future if you decide you do not want to use xdrip-js, or you are having trouble updating OpenAPS with the nodejs update, you can revert the nodejs install with:

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ To look at the Lookout log, for debug purposes, type `cat /var/log/openaps/xdrip
 
 * `--expired_cal`: Lookout uses user entered BG Check and Sensor Start records to calibrate raw unfiltered values reported by the CGM transmitter. Lookout does not perform calibration for 15 minutes after a Sensor Start. During the first 12 hours after a Sensor Start, Lookout only uses a Single Point calibration algorithm that assumes a y axis intercept of 0.  After the first 12 hours, Lookout will switch to using a Least Squares Regression algorithm to calculate the y axis intercept and slope to convert the raw unfiltered values to calibrated glucose values.
 
-**WARNING** Expired calibration mode is in testing phase only and is NOT recommended. It is included in the code at this time so the user can monitor in the log file the delta between the official calibration values and the expired mode calculated calibration values.
+**INFO** Expired calibration mode is in testing phase only and is NOT recommended. It is included in the code at this time so the user can monitor in the log file the delta between the official calibration values and the expired mode calculated calibration values.  The calculation of glucose values from the calculated expired calibration values is disabled.
 
 ## Reverting NodeJS
 

--- a/calibration.js
+++ b/calibration.js
@@ -230,7 +230,7 @@ exports.calcGlucose = (sgv, calibration) => {
   return glucose;
 };
 
-exports.calculateExpiredCalibration = (bgChecks) => {
+exports.expiredCalibration = (bgChecks) => {
   let calPairs = [];
   let calReturn = null;
 

--- a/calibration.js
+++ b/calibration.js
@@ -282,3 +282,26 @@ exports.expiredCalibration = (bgChecks) => {
   return calReturn;
 };
 
+exports.interpolateUnfiltered = (SGVBefore, SGVAfter, valueTime) => {
+  let totalTime = SGVAfter.readDate - SGVBefore.readDate;
+  let totalDelta = SGVAfter.unfiltered - SGVBefore.unfiltered;
+  let fractionTime = (valueTime.valueOf() - SGVBefore.readDate) / totalTime;
+
+  console.log('SGVBefore Time: ' + SGVBefore.readDate + ' SGVBefore Unfiltered: ' + SGVBefore.unfiltered);
+  console.log(' SGVAfter Time: ' + SGVAfter.readDate + '  SGVAfter Unfiltered: ' + SGVAfter.unfiltered);
+
+  if (totalTime > 10*60000) {
+    console.log('Total time exceeds 10 minutes: ' + totalTime + 'ms');
+    console.log('Not interpolating unfiltered values.');
+
+    return null;
+  }
+
+  let returnVal = totalDelta * fractionTime + SGVBefore.unfiltered;
+
+  console.log('  BGCheck Time: ' + valueTime.valueOf() + '       Unfilter Value: ' + (Math.round(returnVal*1000)/1000));
+  console.log('     totalTime: ' + totalTime + ' totalDelta: ' + (Math.round(totalDelta*1000) / 1000) + ' fractionTime: ' + (Math.round(fractionTime*100)/100));
+
+  return returnVal;
+};
+

--- a/calibration.js
+++ b/calibration.js
@@ -254,7 +254,7 @@ exports.expiredCalibration = (bgChecks, sensorInsert) => {
   // remove calPairs that are less than 12 hours from the sensor insert
   if (calPairs.length > 0) {
     for (let i=0; i < calPairs.length; ++i) {
-      if (!sensorInsert || ((calPairs[i].readDateMills - sensorInsert.valueOf()) < 15*60*60000)) {
+      if (!sensorInsert || ((calPairs[i].readDateMills - sensorInsert.valueOf()) < 12*60*60000)) {
         calPairsStart = i+1;
       }
     }
@@ -268,7 +268,7 @@ exports.expiredCalibration = (bgChecks, sensorInsert) => {
   }
 
   // If we have at least 3 good pairs, use LSR
-  if (calPairs.length > 3) {
+  if (calPairs.length >= 3) {
     let calResult = lsrCalibration(calPairs);
 
     if ((calResult.slope > MAXSLOPE) || (calResult.slope < MINSLOPE)) {
@@ -285,7 +285,7 @@ exports.expiredCalibration = (bgChecks, sensorInsert) => {
       type: calResult.calibrationType
     };
 
-    console.log('Expired calibration with LSR:\n', calReturn);
+    console.log('Expired calibration with LSR using ' + calPairs.length + ' calibration pairs:\n', calReturn);
   } else if (calPairs.length > 0) {
     let calResult = singlePointCalibration(calPairs);
 
@@ -297,7 +297,7 @@ exports.expiredCalibration = (bgChecks, sensorInsert) => {
       type: calResult.calibrationType
     };
 
-    console.log('Expired calibration with Single Point:\n', calReturn);
+    console.log('Expired calibration with Single Point due to ' + calPairs.length + ' calibration pairs:\n', calReturn);
   } else {
     console.log('No suitable glucose pairs found for expired calibration.');
   }

--- a/calibration.js
+++ b/calibration.js
@@ -173,7 +173,7 @@ exports.calculateG5Calibration = (lastCal, lastG5CalTime, sensorInsert, glucoseH
       // Only use up to 10 of the most recent suitable readings
       let sgv = glucoseHist[i];
 
-      if ((sgv.readDateMills > (lastG5CalTime + 12*60*1000)) && (!sensorInsert || (sgv.readDateMills > sensorInsert.valueof())) && (sgv.glucose < 300) && (sgv.glucose > 80) && sgv.g5calibrated) {
+      if ((sgv.readDateMills > (lastG5CalTime + 12*60*1000)) && (sgv.glucose < 300) && (sgv.glucose > 80) && sgv.g5calibrated && (!sensorInsert || (sgv.readDateMills > sensorInsert.valueof()))) {
         calPairs.unshift(sgv);
       }
     }

--- a/calibration.js
+++ b/calibration.js
@@ -4,17 +4,20 @@
 //Rule 3 - Only use Single Point Calibration for 1st 12 hours since Sensor insert
 //Rule 4 - Do not store calibration records within 12 hours since Sensor insert. 
 //         Use for SinglePoint calibration, but then discard them
-//Rule 5 - Do not use LSR until we have 4 or more calibration points. 
-//         Use SinglePoint calibration only for less than 4 calibration points. 
+//Rule 5 - Do not use LSR until we have 3 or more calibration points. 
+//         Use SinglePoint calibration only for less than 3 calibration points. 
 //         SinglePoint simply uses the latest calibration record and assumes 
 //         the yIntercept is 0.
-//Rule 6 - Drop back to SinglePoint calibration if slope is out of bounds 
+//Rule 6 - TODO: Drop back to SinglePoint calibration if slope is out of bounds 
 //         (>MAXSLOPE or <MINSLOPE)
-//Rule 7 - Drop back to SinglePoint calibration if yIntercept is out of bounds 
-//        (> minimum unfiltered value in calibration record set or 
-//         < - minimum unfiltered value in calibration record set)
+//Rule 7 - TODO: Drop back to SinglePoint calibration if yIntercept is out of bounds 
+//         (> minimum unfiltered value in calibration record set or 
+//          < - minimum unfiltered value in calibration record set)
 
 var exports = module.exports = {};
+
+const MAXSLOPE = 12500;
+const MINSLOPE = 450;
 
 // calibrationPairs has three values for each array element:
 //   glucose => the "true" glucose value for the pair
@@ -184,7 +187,7 @@ exports.calculateG5Calibration = (lastCal, lastG5CalTime, sensorInsert, glucoseH
     if (((calErr > 5) && calPairs.length > 3) || (calPairs.length > 8)) {
       let calResult = lsrCalibration(calPairs);
 
-      if ((calResult.slope > 12500) || (calResult.slope < 450)) {
+      if ((calResult.slope > MAXSLOPE) || (calResult.slope < MINSLOPE)) {
         // wait until the next opportunity
         console.log('Slope out of range to calibrate: ' + calResult.slope);
         return null;
@@ -249,7 +252,7 @@ exports.expiredCalibration = (bgChecks, sensorInsert) => {
   // remove calPairs that are less than 12 hours from the sensor insert
   if (calPairs.length > 0) {
     for (let i=0; i < calPairs.length; ++i) {
-      if (!sensorInsert || ((calPairs[i].readDate - sensorInsert.valueOf()) < 12*60*60000)) {
+      if (!sensorInsert || ((calPairs[i].readDate - sensorInsert.valueOf()) < 15*60*60000)) {
         calPairsStart = i+1;
       }
     }

--- a/calibration.js
+++ b/calibration.js
@@ -244,7 +244,7 @@ exports.expiredCalibration = (bgChecks, sensorInsert) => {
       calPairs.push({
         unfiltered: bgChecks[i].unfiltered,
         glucose: bgChecks[i].glucose,
-        readDateMills: bgChecks[i].date
+        readDateMills: bgChecks[i].dateMills
       });
     }
   }

--- a/calibration.js
+++ b/calibration.js
@@ -135,7 +135,7 @@ const singlePointCalibration = (calibrationPairs) => {
   return returnVal;
 };
 
-exports.calculateG5Calibration = (lastCal, lastG5CalTime, glucoseHist, currSGV) => {
+exports.calculateG5Calibration = (lastCal, lastG5CalTime, sensorInsert, glucoseHist, currSGV) => {
   // set it to a high number so we upload a new cal
   // if we don't have a previous calibration
 
@@ -168,11 +168,12 @@ exports.calculateG5Calibration = (lastCal, lastG5CalTime, glucoseHist, currSGV) 
     //   greater than 80 mg/dl
     //   calibrated via G5, not Lookout
     //   12 minutes after the last G5 calibration time (it takes up to 2 readings to reflect calibration updates)
+    //   After the latest sensorInsert (ignore sensorInsert if we didn't get one)
     for (i=(glucoseHist.length-1); ((i >= 0) && (calPairs.length < 10)); --i) {
       // Only use up to 10 of the most recent suitable readings
       let sgv = glucoseHist[i];
 
-      if ((sgv.readDateMills > (lastG5CalTime + 12*60*1000)) && (sgv.glucose < 300) && (sgv.glucose > 80) && sgv.g5calibrated) {
+      if ((sgv.readDateMills > (lastG5CalTime + 12*60*1000)) && (!sensorInsert || (sgv.readDateMills > sensorInsert.valueof())) && (sgv.glucose < 300) && (sgv.glucose > 80) && sgv.g5calibrated) {
         calPairs.unshift(sgv);
       }
     }
@@ -248,7 +249,7 @@ exports.expiredCalibration = (bgChecks, sensorInsert) => {
   // remove calPairs that are less than 12 hours from the sensor insert
   if (calPairs.length > 0) {
     for (let i=0; i < calPairs.length; ++i) {
-      if ((calPairs[i].readDate - sensorInsert.valueOf()) < 12*60*60000) {
+      if (!sensorInsert || ((calPairs[i].readDate - sensorInsert.valueOf()) < 12*60*60000)) {
         calPairsStart = i+1;
       }
     }

--- a/calibration.js
+++ b/calibration.js
@@ -154,7 +154,7 @@ exports.calculateG5Calibration = (lastCal, lastG5CalTime, sensorInsert, glucoseH
   var i;
 
   if (lastCal) {
-    calValue = (currSGV.unfiltered-lastCal.intercept)/lastCal.slope;
+    calValue = calcGlucose(currSGV, lastCal);
     calErr = Math.abs(calValue - currSGV.glucose);
 
     console.log('Current calibration error: ' + Math.round(calErr*10)/10 + ' calibrated value: ' + Math.round(calValue*10)/10 + ' slope: ' + Math.round(lastCal.slope*10)/10 + ' intercept: ' + Math.round(lastCal.intercept*10)/10);
@@ -225,7 +225,7 @@ exports.calculateG5Calibration = (lastCal, lastG5CalTime, sensorInsert, glucoseH
   return null;
 };
 
-exports.calcGlucose = (sgv, calibration) => {
+const calcGlucose = (sgv, calibration) => {
   let glucose = Math.round((sgv.unfiltered-calibration.intercept)/calibration.slope);
 
   // If BG is below 40, set it to 39 so it's displayed correctly in NS
@@ -233,6 +233,8 @@ exports.calcGlucose = (sgv, calibration) => {
 
   return glucose;
 };
+
+exports.calcGlucose = calcGlucose;
 
 exports.expiredCalibration = (bgChecks, sensorInsert) => {
   let calPairs = [];

--- a/calibration.js
+++ b/calibration.js
@@ -269,7 +269,7 @@ exports.expiredCalibration = (bgChecks, sensorInsert) => {
   if (calPairs.length > 3) {
     let calResult = lsrCalibration(calPairs);
 
-    if ((calResult.slope > 12.5) || (calResult.slope < 0.45)) {
+    if ((calResult.slope > MAXSLOPE) || (calResult.slope < MINSLOPE)) {
       // wait until the next opportunity
       console.log('Slope out of range to calibrate: ' + calResult.slope);
       return null;

--- a/calibration.js
+++ b/calibration.js
@@ -173,7 +173,7 @@ exports.calculateG5Calibration = (lastCal, lastG5CalTime, sensorInsert, glucoseH
       // Only use up to 10 of the most recent suitable readings
       let sgv = glucoseHist[i];
 
-      if ((sgv.readDateMills > (lastG5CalTime + 12*60*1000)) && (sgv.glucose < 300) && (sgv.glucose > 80) && sgv.g5calibrated && (!sensorInsert || (sgv.readDateMills > sensorInsert.valueof()))) {
+      if ((sgv.readDateMills > (lastG5CalTime + 12*60*1000)) && (sgv.glucose < 300) && (sgv.glucose > 80) && sgv.g5calibrated && (!sensorInsert || (sgv.readDateMills > sensorInsert.valueOf()))) {
         calPairs.unshift(sgv);
       }
     }

--- a/calibration.js
+++ b/calibration.js
@@ -244,7 +244,7 @@ exports.expiredCalibration = (bgChecks, sensorInsert) => {
       calPairs.push({
         unfiltered: bgChecks[i].unfiltered,
         glucose: bgChecks[i].glucose,
-        readDate: bgChecks[i].date
+        readDateMills: bgChecks[i].date
       });
     }
   }
@@ -252,7 +252,7 @@ exports.expiredCalibration = (bgChecks, sensorInsert) => {
   // remove calPairs that are less than 12 hours from the sensor insert
   if (calPairs.length > 0) {
     for (let i=0; i < calPairs.length; ++i) {
-      if (!sensorInsert || ((calPairs[i].readDate - sensorInsert.valueOf()) < 15*60*60000)) {
+      if (!sensorInsert || ((calPairs[i].readDateMills - sensorInsert.valueOf()) < 15*60*60000)) {
         calPairsStart = i+1;
       }
     }
@@ -304,12 +304,12 @@ exports.expiredCalibration = (bgChecks, sensorInsert) => {
 };
 
 exports.interpolateUnfiltered = (SGVBefore, SGVAfter, valueTime) => {
-  let totalTime = SGVAfter.readDate - SGVBefore.readDate;
+  let totalTime = SGVAfter.readDateMills - SGVBefore.readDateMills;
   let totalDelta = SGVAfter.unfiltered - SGVBefore.unfiltered;
-  let fractionTime = (valueTime.valueOf() - SGVBefore.readDate) / totalTime;
+  let fractionTime = (valueTime.valueOf() - SGVBefore.readDateMills) / totalTime;
 
-  console.log('SGVBefore Time: ' + SGVBefore.readDate + ' SGVBefore Unfiltered: ' + SGVBefore.unfiltered);
-  console.log(' SGVAfter Time: ' + SGVAfter.readDate + '  SGVAfter Unfiltered: ' + SGVAfter.unfiltered);
+  console.log('SGVBefore Time: ' + SGVBefore.readDateMills + ' SGVBefore Unfiltered: ' + SGVBefore.unfiltered);
+  console.log(' SGVAfter Time: ' + SGVAfter.readDateMills + '  SGVAfter Unfiltered: ' + SGVAfter.unfiltered);
 
   if (totalTime > 10*60000) {
     console.log('Total time exceeds 10 minutes: ' + totalTime + 'ms');

--- a/index.js
+++ b/index.js
@@ -26,6 +26,6 @@ io.on('connection', (socket) => {
 const argv = require('yargs').argv;
 const TransmitterIO = argv.sim ? require('./transmitterIO-simulated') : require('./transmitterIO');
 
-TransmitterIO(io.of('/cgm'), argv.extend_sensor);
+TransmitterIO(io.of('/cgm'), argv.extend_sensor, argv.expired_cal);
 LoopIO(io.of('/loop'));
 PumpIO(io.of('/pump'));

--- a/syncNS.js
+++ b/syncNS.js
@@ -484,7 +484,7 @@ const syncNS = async (storage) => {
 
       setTimeout(() => {
         // Restart the syncNS after 5 minute
-        syncNS();
+        syncNS(storage);
       }, 5 * 60000);
     });
 };

--- a/syncNS.js
+++ b/syncNS.js
@@ -1,14 +1,13 @@
 'use strict';
 
 const xDripAPS = require('./xDripAPS')();
-const storage = require('node-persist');
 const moment = require('moment');
 const timeLimitedPromise = require('./timeLimitedPromise');
 const storageLock = require('./storageLock');
 
 var _ = require('lodash');
 
-const syncCal = async (sensorInsert) => {
+const syncCal = async (storage, sensorInsert) => {
   let rigCal = null;
   let NSCal = null;
   let nsQueryError = false;
@@ -80,7 +79,7 @@ const syncCal = async (sensorInsert) => {
   console.log('syncCal complete');
 };
 
-const syncSGVs = async () => {
+const syncSGVs = async (storage) => {
   let timeSince = null;
 
   let rigSGVs = null;
@@ -235,7 +234,7 @@ const syncSGVs = async () => {
   console.log('syncSGVs complete');
 };
 
-const syncBGChecks = async (sensorInsert) => {
+const syncBGChecks = async (storage, sensorInsert) => {
   let NSBGChecks = null;
   let nsQueryError = false;
 
@@ -408,7 +407,7 @@ const syncBGChecks = async (sensorInsert) => {
   console.log('syncBGChecks complete');
 };
 
-const syncNS = async () => {
+const syncNS = async (storage) => {
   let sensorInsert = null;
   let nsQueryError = false;
 
@@ -438,17 +437,17 @@ const syncNS = async () => {
   // call resolve so the Promise.all works as it
   // should and doesn't trigger early because of an error
   var syncCalPromise = new timeLimitedPromise(4*60*1000, async (resolve) => {
-    await syncCal(sensorInsert);
+    await syncCal(storage, sensorInsert);
     resolve();
   });
 
   let syncSGVsPromise = new timeLimitedPromise(4*60*1000, async (resolve) => {
-    await syncSGVs();
+    await syncSGVs(storage);
     resolve();
   });
 
   let syncBGChecksPromise = new timeLimitedPromise(4*60*1000, async (resolve) => {
-    await syncBGChecks(sensorInsert);
+    await syncBGChecks(storage, sensorInsert);
     resolve();
   });
 

--- a/syncNS.js
+++ b/syncNS.js
@@ -375,22 +375,24 @@ const syncBGChecks = async (storage, sensorInsert) => {
         // and the current SGV is before valueTime
         SGVBeforeTime = NSSGVs[i].dateMills;
         SGVAfterTime = NSSGVs[i+1].dateMills;
-        if ((SGVBeforeTime <= valueTime) && (SGVAfterTime >= valueTime)) {
+        if (((valueTime - SGVBeforeTime) >= 0) && ((SGVAfterTime - valueTime) >= 0)) {
           SGVBefore = NSSGVs[i];
           SGVAfter = NSSGVs[i+1];
+          break;
         }
       }
 
       if (SGVBefore && SGVAfter) {
-        let totalTime = SGVAfterTime.diff(SGVBeforeTime);
+        let totalTime = SGVAfter.date - SGVBefore.date;
         let totalDelta = SGVAfter.unfiltered - SGVBefore.unfiltered;
-        let fractionTime = valueTime.diff(SGVBeforeTime) / totalTime;
+        let fractionTime = (valueTime.valueOf() - SGVBeforeTime) / totalTime;
 
         rigValue.unfiltered = totalDelta * fractionTime + SGVBefore.unfiltered;
 
-        console.log('Adding unfiltered value, ' + rigValue.unfiltered + ', to BGCheck at ' + valueTime.utc().format());
-        console.log('SGVBefore: \n', SGVBefore);
-        console.log('SGVAfter: \n', SGVAfter);
+        console.log('  BGCheck Time: ' + valueTime.valueOf() + '   Added Filter Value: ' + (Math.round(rigValue.unfiltered*1000)/1000));
+        console.log('SGVBefore Time: ' + SGVBeforeTime + ' SGVBefore Unfiltered: ' + SGVBefore.unfiltered);
+        console.log(' SGVAfter Time: ' + SGVAfterTime + '  SGVAfter Unfiltered: ' + SGVAfter.unfiltered);
+        console.log('     totalTime: ' + totalTime + ' totalDelta: ' + (Math.round(totalDelta*1000) / 1000) + ' fractionTime: ' + (Math.round(fractionTime*100)/100));
       } else {
         console.log('Unable to find bounding SGVs for BG Check at ' + valueTime.format());
       }

--- a/syncNS.js
+++ b/syncNS.js
@@ -476,17 +476,17 @@ const syncNS = async (storage) => {
     resolve();
   });
 
-  Promise.all([syncCalPromise, syncSGVsPromise, syncBGChecksPromise])
+  await Promise.all([syncCalPromise, syncSGVsPromise, syncBGChecksPromise])
     .catch(error => {
       console.log('syncNS error: ' + error);
-    }).then( () => {
-      console.log('syncNS complete - setting 5 minute timer');
-
-      setTimeout(() => {
-        // Restart the syncNS after 5 minute
-        syncNS(storage);
-      }, 5 * 60000);
     });
+
+  console.log('syncNS complete - setting 5 minute timer');
+
+  setTimeout(() => {
+    // Restart the syncNS after 5 minute
+    syncNS(storage);
+  }, 5 * 60000);
 };
 
 module.exports = syncNS;

--- a/syncNS.js
+++ b/syncNS.js
@@ -59,7 +59,7 @@ const syncCal = async (storage, sensorInsert, expiredCal) => {
             console.log('Unable to store NS Calibration');
           });
       }
-    } else if (rigCal.date < NSCal.date) {
+    } else if (rigCal && (rigCal.date < NSCal.date)) {
       if (rigCalStr !== 'expiredCal') {
         console.log('NS calibration more recent than rig calibration NS Cal Date: ' + NSCal.date + ' Rig Cal Date: ' + rigCal.date);
 
@@ -79,7 +79,7 @@ const syncCal = async (storage, sensorInsert, expiredCal) => {
         console.log('NS calibration more recent than rig calibration NS Cal Date: ' + NSCal.date + ' Rig Cal Date: ' + rigCal.date);
         console.log('Currently operating in expired calibration mode - NS Cal matches expired cal.');
       }
-    } else if (rigCal.date > NSCal.date) {
+    } else if (rigCal && (rigCal.date > NSCal.date)) {
       console.log('Rig calibration more recent than NS calibration NS Cal Date: ' + NSCal.date + ' Rig Cal Date: ' + rigCal.date);
       console.log('Upoading rig calibration');
 

--- a/syncNS.js
+++ b/syncNS.js
@@ -412,7 +412,7 @@ const syncBGChecks = async (storage, sensorInsert, expiredCal) => {
         // and the current SGV is before valueTime
         SGVBeforeTime = NSSGVs[i].dateMills;
         SGVAfterTime = NSSGVs[i+1].dateMills;
-        if (((valueTime - SGVBeforeTime) >= 0) && ((SGVAfterTime - valueTime) >= 0)) {
+        if ((SGVBeforeTime < valueTime) && (SGVAfterTime > valueTime)) {
           SGVBefore = NSSGVs[i];
           SGVAfter = NSSGVs[i+1];
           break;
@@ -420,9 +420,9 @@ const syncBGChecks = async (storage, sensorInsert, expiredCal) => {
       }
 
       if (SGVBefore && SGVAfter) {
-        rigValue.unfiltered = calibration.interpolateUnfiltered(xDripAPS.convertEntryToxDrip(SGVBefore), xDripAPS.convertEntryToxDrip(SGVAfter), valueTime);
+        rigValue.unfiltered = calibration.interpolateUnfiltered(xDripAPS.convertEntryToxDrip(SGVBefore), xDripAPS.convertEntryToxDrip(SGVAfter), moment(valueTime));
       } else {
-        console.log('Unable to find bounding SGVs for BG Check at ' + valueTime.format());
+        console.log('Unable to find bounding SGVs for BG Check at ' + moment(valueTime).format());
       }
     }
   }

--- a/syncNS.js
+++ b/syncNS.js
@@ -424,7 +424,12 @@ const syncBGChecks = async (storage, sensorInsert, expiredCal) => {
   }
 
   if (calculateExpiredCal) {
-    let newCal = calibration.expiredCalibration(rigBGChecks);
+    let sensorInsert = await xDripAPS.latestSensorInserted()
+      .catch(error => {
+        console.log('Unable to get latest sensor inserted record from NS: ' + error);
+      });
+
+    let newCal = calibration.expiredCalibration(rigBGChecks, sensorInsert);
 
     await storageLock.lockStorage();
 
@@ -435,7 +440,7 @@ const syncBGChecks = async (storage, sensorInsert, expiredCal) => {
 
     storageLock.unlockStorage();
 
-    if (expiredCal) {
+    if (expiredCal && newCal) {
       xDripAPS.postCalibration(newCal);
     }
   }

--- a/syncNS.js
+++ b/syncNS.js
@@ -433,11 +433,6 @@ const syncBGChecks = async (storage, sensorInsert, expiredCal) => {
   }
 
   if (calculateExpiredCal) {
-    let sensorInsert = await xDripAPS.latestSensorInserted()
-      .catch(error => {
-        console.log('Unable to get latest sensor inserted record from NS: ' + error);
-      });
-
     let newCal = calibration.expiredCalibration(rigBGChecks, sensorInsert);
 
     await storageLock.lockStorage();

--- a/syncNS.js
+++ b/syncNS.js
@@ -169,8 +169,8 @@ const syncSGVs = async (storage) => {
     console.log('Most recent rig SGV - date: ' + moment(sgv.readDate).format() + ' sgv: ' + sgv.glucose + ' unfiltered: ' + sgv.unfiltered);
   }
 
-  for (let nsIndex = 0; nsIndex < nsSGVs.length; ++nsIndex) {
-    let nsSGV = nsSGVs[nsIndex];
+  for (let i = 0; i < nsSGVs.length; ++i) {
+    let nsSGV = nsSGVs[i];
     let rigSGV = null;
 
     for (; rigIndex < rigSGVsLength; ++rigIndex) {
@@ -246,6 +246,7 @@ const syncBGChecks = async (storage, sensorInsert, expiredCal) => {
   let NSBGChecks = null;
   let nsQueryError = false;
   let calculateExpiredCal = false;
+  let sliceStart = 0;
 
   NSBGChecks = await xDripAPS.BGChecksSince(sensorInsert)
     .catch(error => {
@@ -275,6 +276,16 @@ const syncBGChecks = async (storage, sensorInsert, expiredCal) => {
   });
 
   NSBGChecks = _.sortBy(NSBGChecks, ['dateMills']);
+
+  sliceStart = 0;
+
+  for (let i = 0; i < NSBGChecks.length; ++i) {
+    if (moment(NSBGChecks[i].created_at).diff(sensorInsert) < 0) {
+      sliceStart = i+1;
+    }
+  }
+
+  NSBGChecks = NSBGChecks.slice(sliceStart);
 
   if (NSBGChecks.length > 0) {
     let bgCheck = NSBGChecks[NSBGChecks.length-1];
@@ -306,8 +317,8 @@ const syncBGChecks = async (storage, sensorInsert, expiredCal) => {
     console.log('Most recent Rig BG Check - date: ' + moment(bgCheck.date).format() + ' glucose: ' + bgCheck.glucose + ' unfiltered: ' + bgCheck.unfiltered);
   }
 
-  for (let nsIndex = 0; nsIndex < NSBGChecks.length; ++nsIndex) {
-    let nsValue = NSBGChecks[nsIndex];
+  for (let i = 0; i < NSBGChecks.length; ++i) {
+    let nsValue = NSBGChecks[i];
     let rigValue = null;
 
     for (; rigIndex < rigDataLength; ++rigIndex) {
@@ -339,7 +350,7 @@ const syncBGChecks = async (storage, sensorInsert, expiredCal) => {
 
   rigBGChecks = _.sortBy(rigBGChecks, ['dateMills']);
 
-  let sliceStart = 0;
+  sliceStart = 0;
 
   // Remove any cal data we have
   // that predates the last sensor insert

--- a/syncNS.js
+++ b/syncNS.js
@@ -324,6 +324,8 @@ const syncBGChecks = async (storage, sensorInsert, expiredCal) => {
       };
 
       rigBGChecks.push(rigValue);
+
+      // we found a new BG check, trigger calculating new calibration
       calculateExpiredCal = true;
     }
   }

--- a/syncNS.js
+++ b/syncNS.js
@@ -463,7 +463,7 @@ const syncNS = async (storage, expiredCal) => {
 
     setTimeout(() => {
       // Restart the syncNS after 5 minute
-      syncNS();
+      syncNS(storage, expiredCal);
     }, 5 * 60000);
 
     return;
@@ -496,7 +496,7 @@ const syncNS = async (storage, expiredCal) => {
 
   setTimeout(() => {
     // Restart the syncNS after 5 minute
-    syncNS(storage);
+    syncNS(storage, expiredCal);
   }, 5 * 60000);
 };
 

--- a/syncNS.js
+++ b/syncNS.js
@@ -33,7 +33,7 @@ const syncCal = async (storage, sensorInsert, expiredCal) => {
 
   if (expiredCal) {
     rigCalStr = 'expiredCal';
-    console.log('Expired calibration use disabled - synchronized g5 calibration with NS");
+    console.log('Expired calibration use disabled - synchronized g5 calibration with NS');
     rigCalStr = 'g5Calibration';
   } else {
     rigCalStr = 'g5Calibration';

--- a/syncNS.js
+++ b/syncNS.js
@@ -386,16 +386,7 @@ const syncBGChecks = async (storage, sensorInsert, expiredCal) => {
       }
 
       if (SGVBefore && SGVAfter) {
-        let totalTime = SGVAfter.date - SGVBefore.date;
-        let totalDelta = SGVAfter.unfiltered - SGVBefore.unfiltered;
-        let fractionTime = (valueTime.valueOf() - SGVBeforeTime) / totalTime;
-
-        rigValue.unfiltered = totalDelta * fractionTime + SGVBefore.unfiltered;
-
-        console.log('  BGCheck Time: ' + valueTime.valueOf() + '   Added Filter Value: ' + (Math.round(rigValue.unfiltered*1000)/1000));
-        console.log('SGVBefore Time: ' + SGVBeforeTime + ' SGVBefore Unfiltered: ' + SGVBefore.unfiltered);
-        console.log(' SGVAfter Time: ' + SGVAfterTime + '  SGVAfter Unfiltered: ' + SGVAfter.unfiltered);
-        console.log('     totalTime: ' + totalTime + ' totalDelta: ' + (Math.round(totalDelta*1000) / 1000) + ' fractionTime: ' + (Math.round(fractionTime*100)/100));
+        rigValue.unfiltered = calibration.interpolateUnfiltered(xDripAPS.convertEntryToxDrip(SGVBefore), xDripAPS.convertEntryToxDrip(SGVAfter), valueTime);
       } else {
         console.log('Unable to find bounding SGVs for BG Check at ' + valueTime.format());
       }

--- a/syncNS.js
+++ b/syncNS.js
@@ -33,6 +33,8 @@ const syncCal = async (storage, sensorInsert, expiredCal) => {
 
   if (expiredCal) {
     rigCalStr = 'expiredCal';
+    console.log('Expired calibration use disabled - synchronized g5 calibration with NS");
+    rigCalStr = 'g5Calibration';
   } else {
     rigCalStr = 'g5Calibration';
   }
@@ -470,7 +472,8 @@ const syncBGChecks = async (storage, sensorInsert, expiredCal) => {
     storageLock.unlockStorage();
 
     if (expiredCal && newCal) {
-      xDripAPS.postCalibration(newCal);
+      console.log('Expired calibration use disabled - not sending it to NS');
+      // xDripAPS.postCalibration(newCal);
     }
   }
 

--- a/test.js
+++ b/test.js
@@ -125,7 +125,7 @@ describe('Test Calibration', function() {
       'stateString': 'Need calibration',
     };
 
-    let lastCal = calibration.calculateG5Calibration(null, 0, glucoseHist, currSGV);
+    let lastCal = calibration.calculateG5Calibration(null, 0, null, glucoseHist, currSGV);
 
     lastCal.slope.should.be.greaterThan(800);
     lastCal.slope.should.be.lessThan(900);
@@ -182,7 +182,7 @@ describe('Test Calibration', function() {
       'stateString': 'Need calibration',
     };
 
-    let lastCal = calibration.calculateG5Calibration(null, 0, glucoseHist, currSGV);
+    let lastCal = calibration.calculateG5Calibration(null, 0, null, glucoseHist, currSGV);
 
     lastCal.slope.should.be.greaterThan(1050);
     lastCal.slope.should.be.lessThan(1060);

--- a/test.js
+++ b/test.js
@@ -128,7 +128,7 @@ describe('Test Calibration', function() {
     let lastCal = calibration.calculateG5Calibration(null, 0, null, glucoseHist, currSGV);
 
     lastCal.slope.should.be.greaterThan(800);
-    lastCal.slope.should.be.lessThan(900);
+    lastCal.slope.should.be.lessThan(810);
     lastCal.intercept.should.be.greaterThan(33500);
     lastCal.intercept.should.be.lessThan(33600);
     lastCal.type.should.equal('LeastSquaresRegression');

--- a/transmitterIO-simulated.js
+++ b/transmitterIO-simulated.js
@@ -1,6 +1,6 @@
 
 /*eslint-disable no-unused-vars*/
-module.exports = (io, extend_sensor) => {
+module.exports = (io, extend_sensor, expired_cal_opt) => {
 /*eslint-enable no-unused-vars*/
   let id = 'ABCDEF';
   const version = '1.2.3.4';

--- a/transmitterIO.js
+++ b/transmitterIO.js
@@ -550,7 +550,12 @@ module.exports = async (io, extend_sensor_opt, expired_cal_opt) => {
         console.log('Error saving bgChecks: ' + error);
       });
 
-    let newCal = calibration.expiredCalibration(bgChecks);
+    let sensorInsert = await xDripAPS.latestSensorInserted()
+      .catch(error => {
+        console.log('Unable to get latest sensor inserted record from NS: ' + error);
+      });
+
+    let newCal = calibration.expiredCalibration(bgChecks, sensorInsert);
 
     await storage.setItem('expiredCal', newCal)
       .catch((err) => {
@@ -563,7 +568,7 @@ module.exports = async (io, extend_sensor_opt, expired_cal_opt) => {
 
     io.emit('calibrationData', calData);
 
-    if (expired_cal_opt) {
+    if (expired_cal_opt && newCal) {
       xDripAPS.postCalibration(newCal);
     }
   };

--- a/transmitterIO.js
+++ b/transmitterIO.js
@@ -141,6 +141,7 @@ module.exports = async (io, extend_sensor_opt, expired_cal_opt) => {
     if (sensorInsert && lastCal && (sensorInsert.diff(moment(lastCal.date).subtract(6, 'minutes')) > 0) && (lastCal.type !== 'Unity')) {
       console.log('Found sensor insert after latest calibration. Deleting calibration data.');
       await storage.del('g5Calibration');
+      await storage.del('expiredCal');
       await storage.del('bgChecks');
       await storage.del('glucoseHist');
 

--- a/transmitterIO.js
+++ b/transmitterIO.js
@@ -123,7 +123,7 @@ module.exports = async (io, extend_sensor, expired_cal) => {
     }
 
     if (glucoseHist.length > 0) {
-      newCal = calibration.calculateG5Calibration(lastCal, lastG5CalTime, glucoseHist, sgv);
+      newCal = calibration.calculateG5Calibration(lastCal, lastG5CalTime, sensorInsert, glucoseHist, sgv);
 
       if (sgv.state != glucoseHist[glucoseHist.length-1].state) {
         xDripAPS.postAnnouncement('Sensor: ' + sgv.stateString);

--- a/transmitterIO.js
+++ b/transmitterIO.js
@@ -152,7 +152,7 @@ module.exports = async (io, extend_sensor, expired_cal) => {
         console.log('Invalid glucose value received from transmitter, replacing with calibrated unfiltered value from expired calibration algorithm');
         console.log('Calibrated SGV: ' + sgv.glucose + ' unfiltered: ' + sgv.unfiltered + ' slope: ' + lastCal.slope + ' intercept: ' + lastCal.intercept);
 
-        console.log('Expired calibration would be utilized, but is disabled');
+        console.log('Expired calibration use disabled - not replacing invalid glucose');
         sgv.glucose = null;
 
         sgv.g5calibrated = false;
@@ -194,6 +194,9 @@ module.exports = async (io, extend_sensor, expired_cal) => {
         });
 
       if (!expired_cal) {
+        xDripAPS.postCalibration(newCal);
+      } else {
+        console.log('Expired calibration use disabled - sending new G5 calibration to NS');
         xDripAPS.postCalibration(newCal);
       }
     }
@@ -605,7 +608,8 @@ module.exports = async (io, extend_sensor, expired_cal) => {
     io.emit('calibrationData', calData);
 
     if (expired_cal && newCal) {
-      xDripAPS.postCalibration(newCal);
+      console.log('Expired calibration use disabled - not sending it to NS');
+      // xDripAPS.postCalibration(newCal);
     }
   };
 

--- a/transmitterIO.js
+++ b/transmitterIO.js
@@ -630,7 +630,9 @@ module.exports = async (io, extend_sensor, expired_cal) => {
       } else if (m.msg == 'glucose') {
         const glucose = m.data;
 
-        console.log('got glucose: ' + glucose.glucose + ' unfiltered: ' + glucose.unfiltered/1000);
+        glucose.readDateMills = moment(glucose.readDate).valueOf();
+
+        console.log('got glucose: ' + glucose.glucose + ' unfiltered: ' + (glucose.unfiltered/1000));
 
         // restart txFailedReads counter since we were successfull
         txFailedReads = 0;

--- a/transmitterIO.js
+++ b/transmitterIO.js
@@ -522,7 +522,7 @@ module.exports = async (io, extend_sensor_opt, expired_cal_opt) => {
       // Search from the end since in the normal case
       // the G5 cal is processed within 2 readings
       // of the event.
-      for (let i=(rigSGVs.length-1); i >= 0; --i) {
+      for (let i=(rigSGVs.length-2); i >= 0; --i) {
         // Is the next SGV after valueTime
         // and the current SGV is before valueTime
         SGVBeforeTime = rigSGVs[i].readDate;

--- a/transmitterIO.js
+++ b/transmitterIO.js
@@ -557,8 +557,8 @@ module.exports = async (io, extend_sensor, expired_cal) => {
       for (let i=(rigSGVs.length-2); i >= 0; --i) {
         // Is the next SGV after valueTime
         // and the current SGV is before valueTime
-        SGVBeforeTime = rigSGVs[i].readDate;
-        SGVAfterTime = rigSGVs[i+1].readDate;
+        SGVBeforeTime = rigSGVs[i].readDateMills;
+        SGVAfterTime = rigSGVs[i+1].readDateMills;
         if ((valueTime.valueOf() > SGVBeforeTime) && (SGVAfterTime > valueTime.valueOf())) {
           SGVBefore = rigSGVs[i];
           SGVAfter = rigSGVs[i+1];

--- a/transmitterIO.js
+++ b/transmitterIO.js
@@ -149,6 +149,9 @@ module.exports = async (io, extend_sensor, expired_cal) => {
       console.log('Invalid glucose value received from transmitter, replacing with calibrated unfiltered value from expired calibration algorithm');
       console.log('Calibrated SGV: ' + sgv.glucose + ' unfiltered: ' + sgv.unfiltered + ' slope: ' + lastCal.slope + ' intercept: ' + lastCal.intercept);
 
+      console.log('Expired calibration would be utilized, but is disabled');
+      sgv.glucose = null;
+
       sgv.g5calibrated = false;
     }
 

--- a/transmitterIO.js
+++ b/transmitterIO.js
@@ -155,7 +155,9 @@ module.exports = async (io, extend_sensor, expired_cal) => {
       sgv.g5calibrated = false;
     }
 
-    if (sensorInsert && lastCal && (sensorInsert.diff(moment(lastCal.date).subtract(6, 'minutes')) > 0) && (lastCal.type !== 'Unity')) {
+    if (sensorInsert && (lastCal.type !== 'Unity') && 
+      ((lastCal && (sensorInsert.diff(moment(lastCal.date).subtract(6, 'minutes')) > 0))
+      || (lastExpiredCal && (sensorInsert.diff(moment(lastExpiredCal.date).subtract(6, 'minutes')) > 0)))) {
       console.log('Found sensor insert after latest calibration. Deleting calibration data.');
       await storage.del('g5Calibration');
       await storage.del('expiredCal');

--- a/transmitterIO.js
+++ b/transmitterIO.js
@@ -644,7 +644,7 @@ module.exports = async (io, extend_sensor_opt) => {
 
   txId = value || '500000';
 
-  syncNS();
+  syncNS(storage);
 
   listenToTransmitter(txId);
 

--- a/transmitterIO.js
+++ b/transmitterIO.js
@@ -143,16 +143,23 @@ module.exports = async (io, extend_sensor, expired_cal) => {
       sgv.g5calibrated = false;
     }
 
-    if (!sgv.glucose && expired_cal && lastExpiredCal) {
-      sgv.glucose = calibration.calcGlucose(sgv, lastExpiredCal);
+    if (expired_cal && lastExpiredCal) {
+      let expiredCalGlucose = calibration.calcGlucose(sgv, lastExpiredCal);
 
-      console.log('Invalid glucose value received from transmitter, replacing with calibrated unfiltered value from expired calibration algorithm');
-      console.log('Calibrated SGV: ' + sgv.glucose + ' unfiltered: ' + sgv.unfiltered + ' slope: ' + lastCal.slope + ' intercept: ' + lastCal.intercept);
+      if (!sgv.glucose) {
+        sgv.glucose = expiredCalGlucose;
 
-      console.log('Expired calibration would be utilized, but is disabled');
-      sgv.glucose = null;
+        console.log('Invalid glucose value received from transmitter, replacing with calibrated unfiltered value from expired calibration algorithm');
+        console.log('Calibrated SGV: ' + sgv.glucose + ' unfiltered: ' + sgv.unfiltered + ' slope: ' + lastCal.slope + ' intercept: ' + lastCal.intercept);
 
-      sgv.g5calibrated = false;
+        console.log('Expired calibration would be utilized, but is disabled');
+        sgv.glucose = null;
+
+        sgv.g5calibrated = false;
+      } else {
+        let calErr = expiredCalGlucose - sgv.glucose;
+        console.log('Current expired calibration error: ' + Math.round(calErr*10)/10 + ' calibrated value: ' + Math.round(expiredCalGlucose*10)/10 + ' slope: ' + Math.round(lastExpiredCal.slope*10)/10 + ' intercept: ' + Math.round(lastExpiredCal.intercept*10)/10);
+      }
     }
 
     if (sensorInsert && (lastCal.type !== 'Unity') && 

--- a/transmitterIO.js
+++ b/transmitterIO.js
@@ -9,7 +9,7 @@ const stats = require('./calcStats');
 
 var _ = require('lodash');
 
-module.exports = async (io, extend_sensor_opt) => {
+module.exports = async (io, extend_sensor_opt, expired_cal_opt) => {
   let txId;
   let txFailedReads = 0;
   let txStatus = null;
@@ -166,7 +166,9 @@ module.exports = async (io, extend_sensor_opt) => {
           console.log('Unable to store new NS Calibration');
         });
 
-      xDripAPS.postCalibration(newCal);
+      if (!expired_cal_opt) {
+        xDripAPS.postCalibration(newCal);
+      }
     }
 
 
@@ -644,7 +646,7 @@ module.exports = async (io, extend_sensor_opt) => {
 
   txId = value || '500000';
 
-  syncNS(storage);
+  syncNS(storage, expired_cal_opt);
 
   listenToTransmitter(txId);
 

--- a/transmitterIO.js
+++ b/transmitterIO.js
@@ -556,7 +556,7 @@ module.exports = async (io, extend_sensor, expired_cal) => {
         // and the current SGV is before valueTime
         SGVBeforeTime = rigSGVs[i].readDate;
         SGVAfterTime = rigSGVs[i+1].readDate;
-        if (((valueTime.valueOf() - SGVBeforeTime) >= 0) && ((SGVAfterTime - valueTime.valueOf()) >= 0)) {
+        if ((valueTime.valueOf() > SGVBeforeTime) && (SGVAfterTime > valueTime.valueOf())) {
           SGVBefore = rigSGVs[i];
           SGVAfter = rigSGVs[i+1];
           break;

--- a/xDripAPS.js
+++ b/xDripAPS.js
@@ -26,7 +26,7 @@ const _convertEntryToNS = (glucose) => {
 
   console.log('Glucose: ' + glucose.glucose + ' Trend: ' + Math.round(glucose.trend*10)/10 + ' direction: ' + direction);
 
-  return [{
+  return {
     'device': 'xdripjs://' + os.hostname(),
     'date': glucose.readDateMills,
     'dateString': new Date(glucose.readDateMills).toISOString(),
@@ -39,11 +39,11 @@ const _convertEntryToNS = (glucose) => {
     'noise': glucose.nsNoise,
     'trend': glucose.trend,
     'glucose': glucose.glucose
-  }];
+  };
 };
 
 const _convertEntryToxDrip = (glucose) => {
-  return [{
+  return {
     'readDate': glucose.date,
     'filtered': glucose.filtered,
     'unfiltered': glucose.unfiltered,
@@ -51,7 +51,7 @@ const _convertEntryToxDrip = (glucose) => {
     'nsNoise': glucose.noise,
     'trend': glucose.trend,
     'glucose': glucose.glucose
-  }];
+  };
 };
 
 
@@ -341,7 +341,7 @@ module.exports = () => {
   return {
     // API (public) functions
     post: (glucose, sendToXdrip) => {
-      let entry = _convertEntryToNS(glucose);
+      let entry = [ _convertEntryToNS(glucose) ];
 
       if (sendToXdrip) {
         postToXdrip(entry);
@@ -624,11 +624,15 @@ module.exports = () => {
     },
 
     convertEntryToNS: (glucose) => {
-      return _convertEntryToNS(glucose);
+      let retVal = _convertEntryToNS(glucose);
+
+      return retVal;
     },
 
     convertEntryToxDrip: (glucose) => {
-      return _convertEntryToxDrip(glucose);
+      let retVal = _convertEntryToxDrip(glucose);
+
+      return retVal;
     }
   };
 };

--- a/xDripAPS.js
+++ b/xDripAPS.js
@@ -5,7 +5,7 @@ const requestPromise = require('request-promise-native');
 const moment = require('moment');
 const stats = require('./calcStats');
 
-const convertEntry = (glucose) => {
+const _convertEntryToNS = (glucose) => {
   let direction;
 
   if (glucose.trend <= -30) {
@@ -37,6 +37,18 @@ const convertEntry = (glucose) => {
     'unfiltered': glucose.unfiltered,
     'rssi': glucose.rssi,
     'noise': glucose.nsNoise,
+    'trend': glucose.trend,
+    'glucose': glucose.glucose
+  }];
+};
+
+const _convertEntryToxDrip = (glucose) => {
+  return [{
+    'readDate': glucose.date,
+    'filtered': glucose.filtered,
+    'unfiltered': glucose.unfiltered,
+    'rssi': glucose.rssi,
+    'nsNoise': glucose.noise,
     'trend': glucose.trend,
     'glucose': glucose.glucose
   }];
@@ -329,7 +341,7 @@ module.exports = () => {
   return {
     // API (public) functions
     post: (glucose, sendToXdrip) => {
-      let entry = convertEntry(glucose);
+      let entry = _convertEntryToNS(glucose);
 
       if (sendToXdrip) {
         postToXdrip(entry);
@@ -609,6 +621,14 @@ module.exports = () => {
       }
 
       return insertTime;
+    },
+
+    convertEntryToNS: (glucose) => {
+      return _convertEntryToNS(glucose);
+    },
+
+    convertEntryToxDrip: (glucose) => {
+      return _convertEntryToxDrip(glucose);
     }
   };
 };

--- a/xDripAPS.js
+++ b/xDripAPS.js
@@ -44,7 +44,8 @@ const _convertEntryToNS = (glucose) => {
 
 const _convertEntryToxDrip = (glucose) => {
   return {
-    'readDate': glucose.date,
+    'readDateMills': glucose.date,
+    'readDate': glucose.dateString,
     'filtered': glucose.filtered,
     'unfiltered': glucose.unfiltered,
     'rssi': glucose.rssi,


### PR DESCRIPTION
Add expired calibration command line option to calculate calibration values from BG Checks and transmitter reported unfiltered values.

This does not enable using the values, but just calculates them and prints the values to the log file for monitoring the algorithm's effectiveness.