### PR TITLE
Calibrate validation

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -94,13 +94,11 @@ angular.module('AngularOpenAPS', [
         var minValidator = ctrl.$validators.min;
         var maxValidator = ctrl.$validators.max;
 
-        ctrl.$validators.min = function(modelValue, viewValue) {
-          console.log(`in min validator: model = ${modelValue}, view = ${viewValue}`);
+        ctrl.$validators.min = function(modelValue) {
           return minValidator(modelValue, modelValue);
         };
 
         ctrl.$validators.max = function(modelValue) {
-          console.log('in max validator');
           return maxValidator(modelValue, modelValue);
         };
 

--- a/public/app.js
+++ b/public/app.js
@@ -90,10 +90,22 @@ angular.module('AngularOpenAPS', [
     return {
       restrict: 'A',
       require: 'ngModel',
-      link: function (scope, element, attrs, ngModel) {
+      link: function (scope, element, attrs, ctrl) {
+        var minValidator = ctrl.$validators.min;
+        var maxValidator = ctrl.$validators.max;
 
-      // convert value going to user (model to view)
-        ngModel.$formatters.push(function(value) {
+        ctrl.$validators.min = function(modelValue, viewValue) {
+          console.log(`in min validator: model = ${modelValue}, view = ${viewValue}`);
+          return minValidator(modelValue, modelValue);
+        };
+
+        ctrl.$validators.max = function(modelValue) {
+          console.log('in max validator');
+          return maxValidator(modelValue, modelValue);
+        };
+
+        // convert value going to user (model to view)
+        ctrl.$formatters.push(function(value) {
           const units = SharedState.get('glucoseUnits');
           let factor;
 
@@ -109,7 +121,7 @@ angular.module('AngularOpenAPS', [
         });
 
         // value from the user (view to model)
-        ngModel.$parsers.push(function(value) {
+        ctrl.$parsers.push(function(value) {
           const units = SharedState.get('glucoseUnits');
           let factor;
 

--- a/public/cgm/sensor/calibrate.html
+++ b/public/cgm/sensor/calibrate.html
@@ -8,7 +8,7 @@
 
 <div class="scrollable">
   <div class="scrollable-content section">
-    <form role="form" ng-submit="calibrate(value)">
+    <form role="form" name=calibrateform novalidate ng-submit="calibrateform.$valid && calibrate(value)">
       <fieldset>
         <legend>Enter BG meter value</legend>
         <div class="form-group has-success has-feedback">


### PR DESCRIPTION
An option to resolve https://github.com/xdrip-js/Lookout/issues/36. Overrides input validation to use `modelValue` rather than `viewValue`. Also checks whether form is valid before submitting.