### PR TITLE
Release 1.0.2 to Master

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Lookout",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "A web app for communicating with an OpenAPS rig.",
   "main": "index.js",
   "scripts": {
@@ -27,7 +27,7 @@
     "request": "^2.83.0",
     "request-promise-native": "^1.0.5",
     "socket.io": "^1.7.3",
-    "xdrip-js": "xdrip-js/xdrip-js",
+    "xdrip-js": "xdrip-js/xdrip-js#v1.2.0",
     "yargs": "^10.0.3"
   },
   "devDependencies": {


### PR DESCRIPTION
Lock xdrip-js version dependency to prevent compatibility errors.