### PR TITLE
Fix transmitter calibrate logic error

### DIFF
--- a/calibration.js
+++ b/calibration.js
@@ -203,7 +203,7 @@ const calculateTxmitterCalibration = (
   }
 
   // Check if we need a calibration
-  if (!lastCal || (calErr > 5) || (lastCal.type === 'SinglePoint')) {
+  if (!lastCal || (calErr > 5) || (lastCal.type === 'Unity') || (lastCal.type === 'SinglePoint')) {
     calPairs.push(currSGV);
 
     // Suitable values need to be:


### PR DESCRIPTION
If the current calibration record is a `Unity` record, but it's provides calibrated glucose within tolerances, it won't update it with a "valid" record.