### PR TITLE
Support selecting bluetooth adapter

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,6 +56,12 @@ const argv = yargs
     alias: 'p',
     default: 3000,
   })
+  .option('hci', {
+    nargs: 1,
+    describe: 'Bluetooth adapter to use',
+    alias: 'h',
+    default: 0,
+  })
   .option('openaps', {
     nargs: 1,
     describe: 'OpenAPS directory',
@@ -114,6 +120,7 @@ const options = {
   max_lsr_pairs: params.max_lsr_pairs,
   max_lsr_pairs_age: params.max_lsr_pairs_age,
   include_mode: params.include_mode,
+  hci: params.hci,
 };
 
 const init = async () => {
@@ -136,6 +143,9 @@ const init = async () => {
       Debug.enable('*,*:*');
     }
   }
+
+  // Set which device for noble to use
+  process.env.NOBLE_HCI_DEVICE_ID = params.hci;
 
   // handle persistence here
   // make the storage direction relative to the install directory,

--- a/transmitterIO.js
+++ b/transmitterIO.js
@@ -91,7 +91,7 @@ module.exports = async (options, storage, storageLock, client, fakeMeter) => {
   };
 
   const removeBTDevice = (btName) => {
-    cp.exec(`bt-device -r ${btName}`, (err, stdout, stderr) => {
+    cp.exec(`bt-device -a hci${options.hci} -r ${btName}`, (err, stdout, stderr) => {
       if (err) {
         debug(`Unable to remove BT Device: ${btName} - ${err}`);
         return;


### PR DESCRIPTION
On systems with more than one Bluetooth adapter, noble only supports one and needs to know which one to connect to.

Also, bt-device needs to know which adapter to command.