### PR TITLE
Shortened pre-wakup-scan time

### DIFF
--- a/transmitterIO.js
+++ b/transmitterIO.js
@@ -13,7 +13,7 @@ const xDripAPS = require('./xDripAPS')();
 
 const FIVE_MINUTES = 5 * 60 * 1000;
 const SIX_MINUTES = 6 * 60 * 1000;
-const PRE_TX_WAKUP_BUFFER = 10 * 1000;
+const PRE_TX_WAKUP_BUFFER = 0 * 1000;
 
 module.exports = async (options, storage, client, fakeMeter) => {
   let txId;

--- a/transmitterIO.js
+++ b/transmitterIO.js
@@ -12,7 +12,7 @@ const calibration = require('./calibration');
 const xDripAPS = require('./xDripAPS')();
 
 const FIVE_MINUTES = 5 * 60 * 1000;
-const SIX_MINUTES = 6 * 60 * 1000;
+const RESTART_LISTEN_TIME = 6.5 * 60 * 1000;
 const PRE_TX_WAKUP_BUFFER = 0 * 1000;
 
 module.exports = async (options, storage, client, fakeMeter) => {
@@ -1379,7 +1379,7 @@ module.exports = async (options, storage, client, fakeMeter) => {
           error(`Unable to kill existing worker: ${err}`);
         }
       }
-    }, SIX_MINUTES);
+    }, RESTART_LISTEN_TIME);
   };
 
   const changeTxId = (value) => {


### PR DESCRIPTION
The transmitter starts advertising ten seconds after it collects the glucose reading. Reduce the pre-wakeup-scan timeout to account for this.

Extend the restart listen to transmitter timeout by 30 seconds.